### PR TITLE
Allow fetching source JARs, update to latest JMH and rules_jvm_external

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ load("@rules_jmh//:defs.bzl", "rules_jmh_maven_deps")
 rules_jmh_maven_deps()
 ```
 
+`rules_jmh_maven_deps` accepts extra arguments, for example:
+
+```python
+
+# Download JMH source JARs
+rules_jmh_maven_deps(fetch_sources = True)
+
+# Use another version
+rules_jmh_maven_deps(version = "1.21")
+```
+
 You can specify JMH benchmarks by using the `jmh_java_benchmarks` rule. It takes the same arguments as `java_binary` except for `main_class`. One can specify one or more JMH benchmarks in the `srcs` attribute.
 
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -1,8 +1,9 @@
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 def rules_jmh_maven_deps(
-    jmh_version = "1.21",
-    repositories = ["https://repo1.maven.org/maven2"]):
+    jmh_version = "1.23",
+    repositories = ["https://repo1.maven.org/maven2"],
+    **kwargs):
     """Loads the maven dependencies of rules_jmh.
 
     Args:
@@ -18,6 +19,7 @@ def rules_jmh_maven_deps(
             "org.openjdk.jmh:jmh-generator-annprocess:{}".format(jmh_version),
         ],
         repositories = repositories,
+        **kwargs
     )
 
 def jmh_java_benchmarks(name, srcs, deps=[], tags=[], plugins=[], **kwargs):

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,10 +1,10 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-def rules_jmh_deps():
+def rules_jmh_deps(rules_jvm_external_tag="3.2", rules_jvm_external_sha = "82262ff4223c5fda6fb7ff8bd63db8131b51b413d26eb49e3131037e79e324af"):
   if "rules_jvm_external" not in native.existing_rules():
     http_archive(
-      name = "rules_jvm_external",
-      strip_prefix = "rules_jvm_external-1.2",
-      sha256 = "e5c68b87f750309a79f59c2b69ead5c3221ffa54ff9496306937bfa1c9c8c86b",
-      url = "https://github.com/bazelbuild/rules_jvm_external/archive/1.2.zip"
+        name = "rules_jvm_external",
+        sha256 = rules_jvm_external_sha,
+        strip_prefix = "rules_jvm_external-%s" % rules_jvm_external_tag,
+        url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % rules_jvm_external_tag,
     )


### PR DESCRIPTION
Hi @buchgr , can you please review these changes (I'm using them here: https://github.com/MihaiBojin/props)?

- updated `rules_jvm_external` to latest version
- also allow changing the version/sha of `rules_jvm_external`
- updated JMH to latest version (1.23)
- and allow specifying additional args (e.g. `fetch_sources`)

Thanks!